### PR TITLE
fix: 好感度标签被 meme_manager 误删导致永不更新

### DIFF
--- a/main.py
+++ b/main.py
@@ -2018,9 +2018,9 @@ class FavourManagerTool(Star):
         except Exception as e:
             logger.error(f"注入好感度Prompt失败: {str(e)}\n{traceback.format_exc()}")
 
-    @filter.on_llm_response(priority=10)
+    @filter.on_llm_response(priority=100000)
     async def handle_llm_response(self, event: AstrMessageEvent, resp: LLMResponse) -> None:
-        """优先读取好感度标签（priority=10 确保在其他钩子之前执行）。"""
+        """优先读取好感度标签（priority=100000 确保在 meme_manager(99999) 等其他钩子之前解析好感度标签）。"""
         if not hasattr(event, 'message_obj'): return
         
         # 搭话合成事件：不记录好感度变更（搭话不应影响好感度）


### PR DESCRIPTION
根因: on_llm_response 钩子 priority=10 低于 meme_manager 的 99999, meme_manager 用 \[([^\[\]]+)\] 清理方括号标记时, 会把 [好感度 上升:X] 等标签当作非法表情标记静默删除并写回 completion_text, 导致 favour_pattern 永远匹配不到标签, 好感度自 7 月 18 日以来 0 更新.

修复: 将 on_llm_response priority 提升至 100000, 确保在 meme_manager 之前完成好感度标签解析.